### PR TITLE
Error when RUBY_UID is not passed in instead of setting default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     build:
       context: .
       args:
-        - UID=${RUBY_UID-1000}
-        - GID=${RUBY_GID-1000}
+        - UID=${RUBY_UID:?err}
+        - GID=${RUBY_UID:?err}
     volumes:
       - .:/gem:cached
       - gems:/gems


### PR DESCRIPTION
This PR changes from setting a default for the UID and GID build args to erroring. It also changes it to only requiring RUBY_UID to be passed in which is helpful when running on a Mac.