### PR TITLE
Fix rspec_config_hooks_for for all envs

### DIFF
--- a/spec/support/spec_helper_methods.rb
+++ b/spec/support/spec_helper_methods.rb
@@ -14,7 +14,7 @@ module SpecHelperMethods
 
     hook_ptr.flatten.select do |item|
       next unless item.respond_to?(:block)
-      item.block.source_location.first.include?("selective/lib")
+      item.block.source_location.first.include?("lib/selective.rb")
     end
   end
 end


### PR DESCRIPTION
This helper method had an unintentional dependency on where the selective gem was located. This change ensures that the filter selects the right blocks in any environment.