### PR TITLE
Generate unique coverage_path to support multiple rspec processes

### DIFF
--- a/lib/selective/config.rb
+++ b/lib/selective/config.rb
@@ -24,7 +24,7 @@ module Selective
     ].freeze
 
     DEFAULT_BACKEND_HOST       = "https://selective-ci.herokuapp.com"
-    DEFAULT_COVERAGE_PATH      = "/tmp/coverage-map.yml"
+    DEFAULT_COVERAGE_PATH      = "/tmp"
     DEFAULT_WEBPACKER_LOCATION = File.join("app", "javascript").freeze
 
     private_constant :DEFAULT_BACKEND_HOST
@@ -39,7 +39,7 @@ module Selective
       @report_callgraph_check = proc { !ENV["SELECTIVE_REPORT_CALLGRAPH"].nil? }
       @select_tests_check = proc { !ENV["SELECTIVE_SELECT_TESTS"].nil? }
       @sprockets_asset_collector_class = Collectors::SprocketsAssetCollector
-      @coverage_path = Pathname.new(DEFAULT_COVERAGE_PATH)
+      @coverage_path = Pathname.new(DEFAULT_COVERAGE_PATH).join("#{SecureRandom.urlsafe_base64}.yml")
       @webpacker_app_locations = [DEFAULT_WEBPACKER_LOCATION]
     end
   end

--- a/spec/lib/selective/config_spec.rb
+++ b/spec/lib/selective/config_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Selective::Config do
       expect(object.sprockets_asset_collector_class)
         .to eql(Selective::Collectors::SprocketsAssetCollector)
       expect(object.coverage_path).to be_a(Pathname)
-      expect(object.coverage_path.to_s).to eql("/tmp/coverage-map.yml")
+      expect(object.coverage_path.to_s).to match(%r{/tmp/.*\.yml})
       expect(object.api_key).to eql(ENV.fetch("SELECTIVE_API_KEY", nil))
     end
   end


### PR DESCRIPTION
Gems like parallel_tests use multiple processes at once, requiring us to ensure selective writes coverage info to unique files.