### PR TITLE
Cleanup/20201120

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push]
 
 env:
   CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   test:

--- a/lib/selective.rb
+++ b/lib/selective.rb
@@ -81,7 +81,7 @@ module Selective
         end
 
         config.around(:example) do |example|
-          if Selective.selected_tests.blank? || (Selective.selected_tests & [example.id, example.file_path]).any?
+          if run_example?(example)
             example.run
           else
             Selective.skipped_tests << example.id
@@ -89,8 +89,8 @@ module Selective
         end
 
         config.after(:suite) do |suite|
-          suite.reporter.examples.delete_if { |e| Selective.skipped_tests.include?(e.id) }
-          suite.reporter.pending_examples.delete_if { |e| Selective.skipped_tests.include?(e.id) }
+          suite.reporter.examples.delete_if(&method(:skipped_test?))
+          suite.reporter.pending_examples.delete_if(&method(:skipped_test?))
         end
       end
     end
@@ -117,6 +117,16 @@ module Selective
 
     def exclude_file?(file)
       config.file_exclusion_check.call(file)
+    end
+
+    def run_example?(example)
+      return true if Selective.selected_tests.blank?
+
+      (Selective.selected_tests & [example.id, example.file_path]).any?
+    end
+
+    def skipped_test?(example)
+      Selective.skipped_tests.include?(example.id)
     end
   end
 end

--- a/lib/selective.rb
+++ b/lib/selective.rb
@@ -102,7 +102,7 @@ module Selective
     def start_coverage
       return unless report_callgraph?
 
-      coverage_collectors.values.each do |coverage_collector|
+      coverage_collectors.each_value do |coverage_collector|
         coverage_collector.on_start
       end
     end

--- a/lib/selective.rb
+++ b/lib/selective.rb
@@ -100,10 +100,10 @@ module Selective
     end
 
     def start_coverage
-      if report_callgraph?
-        coverage_collectors.values.each do |coverage_collector|
-          coverage_collector.on_start
-        end
+      return unless report_callgraph?
+
+      coverage_collectors.values.each do |coverage_collector|
+        coverage_collector.on_start
       end
     end
 

--- a/lib/selective/api.rb
+++ b/lib/selective/api.rb
@@ -23,7 +23,9 @@ module Selective
       }
 
       # Parse response
-      JSON.parse(response.body) if response.body.present?
+      if response.body.present?
+        JSON.parse(response.body)
+      end
     end
   end
 end

--- a/lib/selective/api.rb
+++ b/lib/selective/api.rb
@@ -3,12 +3,12 @@ require "json"
 
 module Selective
   module Api
-    def self.request(path, body=nil, method: :get)
+    def self.request(path, body = nil, method: :get)
       uri = URI.parse("#{Selective.config.backend_host}/api/v1/#{path}")
       headers = {:"Content-Type" => "application/json", "X-API-KEY" => Selective.config.api_key}
 
       # Create the HTTP objects
-      response = Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") { |http|
         if method == :get
           request = Net::HTTP::Get.new(uri.request_uri, headers)
         elsif method == :post
@@ -20,7 +20,7 @@ module Selective
 
         # Send the request
         http.request(request)
-      end
+      }
 
       # Parse response
       JSON.parse(response.body) if response.body.present?

--- a/lib/selective/api.rb
+++ b/lib/selective/api.rb
@@ -9,14 +9,18 @@ module Selective
 
       # Create the HTTP objects
       response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") { |http|
-        if method == :get
-          request = Net::HTTP::Get.new(uri.request_uri, headers)
-        elsif method == :post
-          request = Net::HTTP::Post.new(uri.request_uri, headers)
-        else
-          raise "Invalid method"
+        request = case method
+          when :get
+            Net::HTTP::Get.new(uri.request_uri, headers)
+          when :post
+            Net::HTTP::Post.new(uri.request_uri, headers)
+          else
+            raise "Invalid method"
         end
-        request.body = body.to_json if body.present?
+
+        if body.present?
+          request.body = body.to_json
+        end
 
         # Send the request
         http.request(request)

--- a/lib/selective/collector.rb
+++ b/lib/selective/collector.rb
@@ -18,18 +18,17 @@ module Selective
     def start_recording_code_coverage
       return unless Selective.report_callgraph?
 
-      coverage_collectors.each do |_coverage_collector_class, coverage_collector|
-        coverage_collector.on_start
-      end
+      coverage_collectors.each_value(&:on_start)
     end
 
     def write_code_coverage_artifact(example_id)
       return unless Selective.report_callgraph?
 
       cleaned_coverage = {}.tap do |cleaned|
-        coverage_collectors.values.each do |coverage_collector|
+        coverage_collectors.each_value do |coverage_collector|
           coverage_collector.covered_files.each do |covered_file, coverage_data|
             next if Selective.exclude_file?(covered_file)
+
             cleaned[covered_file] ||= {}
             cleaned[covered_file][coverage_collector.class.name] = coverage_data
           end

--- a/lib/selective/collector.rb
+++ b/lib/selective/collector.rb
@@ -36,14 +36,19 @@ module Selective
         end
       end
 
-      map[example_id] = cleaned_coverage if cleaned_coverage.present?
+      if cleaned_coverage.present?
+        map[example_id] = cleaned_coverage
+      end
+
       check_dump_threshold
     end
 
     def finalize
       return unless Selective.report_callgraph?
 
-      map_storage.dump(map) if map.size.positive?
+      if map.any?
+        map_storage.dump(map)
+      end
 
       # If by some chance no coverage information
       # has been written, there is nothing to

--- a/lib/selective/collectors/action_view/rendered_template_collector.rb
+++ b/lib/selective/collectors/action_view/rendered_template_collector.rb
@@ -14,10 +14,10 @@ module Selective
           end
 
           def unsubscribe
-            if @subscriber
-              ActiveSupport::Notifications.unsubscribe(@subscriber)
-              @subscriber = nil
-            end
+            return unless @subscriber
+
+            ActiveSupport::Notifications.unsubscribe(@subscriber)
+            @subscriber = nil
           end
         end
 

--- a/lib/selective/collectors/ruby_coverage_collector.rb
+++ b/lib/selective/collectors/ruby_coverage_collector.rb
@@ -9,7 +9,9 @@ module Selective
 
       def initialize(root_path = Dir.pwd)
         require "coverage"
-        Coverage.start unless Coverage.running?
+        unless Coverage.running?
+          Coverage.start
+        end
         @root_path = root_path
       end
 

--- a/lib/selective/collectors/webpacker/helpers.rb
+++ b/lib/selective/collectors/webpacker/helpers.rb
@@ -5,11 +5,15 @@ module Selective
     module Webpacker
       module Helpers
         def javascript_packs_with_chunks_tag(*names, **options)
-          raise(StandardError, "Selective.config.webpacker_app_locations must be set to collect webpacker app coverage") if Selective.config.webpacker_app_locations.blank?
+          if Selective.config.webpacker_app_locations.blank?
+            raise(StandardError, "Selective.config.webpacker_app_locations must be set to collect webpacker app coverage")
+          end
 
           globs = names.flat_map { |name|
             app_home = javascript_app_home(name)
-            raise(StandardError, "Unable to locate source location for javascript app #{name}") unless Dir.exist?(app_home)
+            unless Dir.exist?(app_home)
+              raise(StandardError, "Unable to locate source location for javascript app #{name}")
+            end
 
             [
               File.join(app_home, "src", "**.{scss,css,js}"),

--- a/lib/selective/config.rb
+++ b/lib/selective/config.rb
@@ -23,8 +23,8 @@ module Selective
       Selective::Collectors::Webpacker::WebpackerAppCollector
     ].freeze
 
-    DEFAULT_BACKEND_HOST       = "https://selective-ci.herokuapp.com"
-    DEFAULT_COVERAGE_PATH      = "/tmp"
+    DEFAULT_BACKEND_HOST = "https://selective-ci.herokuapp.com"
+    DEFAULT_COVERAGE_PATH = "/tmp"
     DEFAULT_WEBPACKER_LOCATION = File.join("app", "javascript").freeze
 
     private_constant :DEFAULT_BACKEND_HOST

--- a/lib/selective/minitest.rb
+++ b/lib/selective/minitest.rb
@@ -30,8 +30,8 @@ module Selective
         def process_args(args = [])
           Selective.selected_tests = Selective::Selector.tests_from_diff
           if Selective.selected_tests.any?
-            regex = '/' + Selective.selected_tests.join('|') + '/'
-            args.concat(['--name', regex])
+            regex = "/" + Selective.selected_tests.join("|") + "/"
+            args.concat(["--name", regex])
           end
           super
         end

--- a/lib/selective/storage.rb
+++ b/lib/selective/storage.rb
@@ -35,7 +35,9 @@ module Selective
 
     # Removes storage file
     def clear!
-      path.delete if path.exist?
+      return unless path.exist?
+
+      path.delete
     end
 
     # Writes data to storage file

--- a/spec/lib/selective_spec.rb
+++ b/spec/lib/selective_spec.rb
@@ -374,4 +374,61 @@ RSpec.describe Selective do
       expect(result).to be false
     end
   end
+
+  describe ".run_example?" do
+    let(:file_path) { "./spec/foo/bar_spec.rb" }
+    let(:example) { double(:example, run: nil, id: "foobar", file_path: file_path) }
+
+    it "returns true if no selected tests" do
+      allow(described_class).to receive(:selected_tests).and_return([])
+
+      result = described_class.run_example?(example)
+
+      expect(result).to be true
+    end
+
+    it "returns true if example id was selected" do
+      allow(described_class).to receive(:selected_tests).and_return(["foobar"])
+
+      result = described_class.run_example?(example)
+
+      expect(result).to be true
+    end
+
+    it "returns true if example filepath was selected" do
+      allow(described_class).to receive(:selected_tests).and_return([file_path])
+
+      result = described_class.run_example?(example)
+
+      expect(result).to be true
+    end
+
+    it "returns false if example id/path were not selected" do
+      allow(described_class).to receive(:selected_tests).and_return(["baz"])
+
+      result = described_class.run_example?(example)
+
+      expect(result).to be false
+    end
+  end
+
+  describe ".skipped_test?" do
+    let(:example) { double(:example, run: nil, id: "foobar", file_path: nil) }
+
+    it "returns true if test was skipped" do
+      allow(described_class).to receive(:skipped_tests).and_return(["foobar"])
+
+      result = described_class.skipped_test?(example)
+
+      expect(result).to be true
+    end
+
+    it "returns false if test was not skipped" do
+      allow(described_class).to receive(:skipped_tests).and_return(["baz"])
+
+      result = described_class.skipped_test?(example)
+
+      expect(result).to be false
+    end
+  end
 end

--- a/spec/selective/minitest_spec.rb
+++ b/spec/selective/minitest_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Selective::Minitest do
 
   class ReportingPluginTester < ReportingPluginTesterSuperclass
     def name
-      'sample_test_method'
+      "sample_test_method"
     end
 
     include Selective::Minitest::Reporting::Plugin
   end
 
   class SelectionPluginTesterSuperclass
-    def process_args(args=[])
+    def process_args(args = [])
       @superclass_args = args
     end
   end
@@ -38,18 +38,18 @@ RSpec.describe Selective::Minitest do
         allow(Selective).to receive(:collector).and_return(double)
       end
 
-      describe '#before_setup' do
-        it 'calls superclass before_setup and starts recording code coverage' do
+      describe "#before_setup" do
+        it "calls superclass before_setup and starts recording code coverage" do
           expect(Selective.collector).to receive(:start_recording_code_coverage)
           reporting_plugin_tester.before_setup
           expect(reporting_plugin_tester.instance_variable_get(:@super_before_setup_called)).to be true
         end
       end
 
-      describe '#after_teardown' do
-        let(:test_identifier) { 'ReportingPluginTester#sample_test_method' }
+      describe "#after_teardown" do
+        let(:test_identifier) { "ReportingPluginTester#sample_test_method" }
 
-        it 'writes code coverage artifact and calls super' do
+        it "writes code coverage artifact and calls super" do
           expect(Selective.collector).to receive(:write_code_coverage_artifact).with(test_identifier)
           reporting_plugin_tester.after_teardown
           expect(reporting_plugin_tester.instance_variable_get(:@super_after_teardown_called)).to be true
@@ -57,14 +57,14 @@ RSpec.describe Selective::Minitest do
       end
     end
 
-    describe '.hook' do
-      it 'includes the reporting plugin' do
-        expect(::Minitest::Test).to receive(:include).
-          with(Selective::Minitest::Reporting::Plugin)
+    describe ".hook" do
+      it "includes the reporting plugin" do
+        expect(::Minitest::Test).to receive(:include)
+          .with(Selective::Minitest::Reporting::Plugin)
         Selective::Minitest::Reporting.hook
       end
 
-      it 'add finalize as an after_run' do
+      it "add finalize as an after_run" do
         expect(::Minitest).to receive(:after_run)
         Selective::Minitest::Reporting.hook
       end
@@ -76,39 +76,39 @@ RSpec.describe Selective::Minitest do
       let(:selection_plugin_tester) { SelectionPluginTester.new }
       let(:superclass_args) { selection_plugin_tester.instance_variable_get(:@superclass_args) }
 
-      context 'when selected tests are returned' do
-        it 'inserts name filter args from selected tests' do
+      context "when selected tests are returned" do
+        it "inserts name filter args from selected tests" do
           expect(Selective::Selector).to receive(:tests_from_diff) do
             [
-              'SampleTestClass#sample_test_method1',
-              'SampleTestClass#sample_test_method2'
+              "SampleTestClass#sample_test_method1",
+              "SampleTestClass#sample_test_method2"
             ]
           end
-          selection_plugin_tester.process_args(['--foo', 'bar'])
+          selection_plugin_tester.process_args(["--foo", "bar"])
           expect(superclass_args).to eq(
             [
-              '--foo',
-              'bar',
-              '--name',
-              '/SampleTestClass#sample_test_method1|SampleTestClass#sample_test_method2/',
+              "--foo",
+              "bar",
+              "--name",
+              "/SampleTestClass#sample_test_method1|SampleTestClass#sample_test_method2/"
             ]
           )
         end
       end
 
-      context 'when no selected tests returned' do
-        it 'does not alter args' do
+      context "when no selected tests returned" do
+        it "does not alter args" do
           expect(Selective::Selector).to receive(:tests_from_diff).and_return([])
-          selection_plugin_tester.process_args(['--foo', 'bar'])
-          expect(superclass_args).to eq(['--foo', 'bar'])
+          selection_plugin_tester.process_args(["--foo", "bar"])
+          expect(superclass_args).to eq(["--foo", "bar"])
         end
       end
     end
 
-    describe '.hook' do
-      it 'prepends the selection plugin' do
-        expect(::Minitest.singleton_class).to receive(:prepend).
-          with(Selective::Minitest::Selection::Plugin)
+    describe ".hook" do
+      it "prepends the selection plugin" do
+        expect(::Minitest.singleton_class).to receive(:prepend)
+          .with(Selective::Minitest::Selection::Plugin)
         Selective::Minitest::Selection.hook
       end
     end


### PR DESCRIPTION
We can discard this if you like. In general, this:

- applies recommended standardrb linting
- prefers using a guard clause over nesting code inside a conditional
- prefers multi-line condition/code vs one-liners. mainly to improve accuracy of LOC coverage - when one line, you don't know if the code inside the conditional is tested
- extracts a couple of predicate methods/adds specs
- uses a case statement vs if/elsif/else
- uses `each_value` vs `values.each` or `each { |_, v|`