### PR TITLE
Ensure methods in scope

### DIFF
--- a/lib/selective.rb
+++ b/lib/selective.rb
@@ -81,7 +81,7 @@ module Selective
         end
 
         config.around(:example) do |example|
-          if run_example?(example)
+          if Selective.run_example?(example)
             example.run
           else
             Selective.skipped_tests << example.id
@@ -89,8 +89,12 @@ module Selective
         end
 
         config.after(:suite) do |suite|
-          suite.reporter.examples.delete_if(&method(:skipped_test?))
-          suite.reporter.pending_examples.delete_if(&method(:skipped_test?))
+          suite.reporter.examples.delete_if do |e|
+            Selective.skipped_test?(e)
+          end
+          suite.reporter.pending_examples.delete_if do |e|
+            Selective.skipped_test?(e)
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes an issue where method calls in rspec hooks are not in scope when executed. Will circle back around Friday to beef up the specs in this area of the gem.